### PR TITLE
Examinable species

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -142,6 +142,7 @@
 #define HEADCOVERSEYES		(1<<2)		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		(1<<3)		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		(1<<4)
+#define SPECIES_SHOWN		(1<<14)		//Used in check_obscured_slots() and examine.dm
 
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -18,6 +18,10 @@
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
+	//species check
+	if(!(SPECIES_SHOWN in obscured))
+		msg += "[t_He] [t_is] a [dna.species.name].\n"
+
 	//uniform
 	if(w_uniform && !(SLOT_W_UNIFORM in obscured))
 		//accessory

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -534,6 +534,10 @@
 		if(wear_mask.flags_inv & HIDEEYES)
 			obscured |= SLOT_GLASSES
 
+	if(dna.species)
+		if(SLOT_W_UNIFORM in obscured && SLOT_WEAR_MASK in obscured)
+			obscured |= SPECIES_SHOWN
+
 	if(obscured.len)
 		return obscured
 	else


### PR DESCRIPTION
Examining someone who doesn't have full-body coverage (such as a biosuit) can have their species seen through examine text.

Mostly because Romulans and Vulcans are really hard to tell from a human with 32x32 pixels.